### PR TITLE
feat: add PR labeler GitHub Actions workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+area:api:
+  - src/api/**/*
+  - src/**/api/**/*
+area:frontend:
+  - app/**/*
+area:infra:
+  - .github/**/*
+  - pyproject.toml
+python:
+  - "**/*.py"
+documentation:
+  - "**/*.md"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "Pull Request Labeler"
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary

Added GitHub Actions PR labeler workflow to automatically label pull requests based on modified files.

## Motivation

Improves PR triage by automatically applying labels based on which files are changed, making it easier to categorize contributions.

## Changes
- Added .github/workflows/labeler.yml with pull_request_target trigger
- Added .github/labeler.yml with path-to-label mappings

## Testing

No code changes — CI workflow and config files only.

```bash
pytest tests/ -q
ruff check .
pyright src/fu7ur3pr00f
```

## Checklist

- [ ] Tests pass locally
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`pyright src/fu7ur3pr00f`)
- [ x] Changes are backwards compatible
- [ x] Documentation updated (if needed)

## Screenshots (if applicable)

<!-- For UI changes, include before/after screenshots -->

## Related Issues

<!-- Link related issues: Fixes #123 -->
Fixes #39