### PR TITLE
fix: allow ollama base_url to be None in OllamaEmbeddingFunction

### DIFF
--- a/src/fu7ur3pr00f/memory/embeddings.py
+++ b/src/fu7ur3pr00f/memory/embeddings.py
@@ -137,10 +137,10 @@ class OllamaEmbeddingFunction(EmbeddingFunction[Documents]):
 
     def __init__(
         self,
-        base_url: str = "http://localhost:11434",
+        base_url: str | None = None,
         model: str = "nomic-embed-text",
     ) -> None:
-        self._base_url = base_url
+        self._base_url = base_url or "http://localhost:11434"
         self._model = model
         self._client: Any = None
 


### PR DESCRIPTION
Fixes pyright type error blocking all CI runs.

`OllamaEmbeddingFunction.__init__` expected `base_url: str` but `settings.ollama_base_url` is `str | None`.

Changed to accept `str | None` with fallback to `http://localhost:11434`.

Unblocks PRs #43 and #44.