### PR TITLE
fix: update labeler config to v5 format (any/keys)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,17 @@
 area:api:
-  - src/api/**/*
-  - src/**/api/**/*
+  - any:
+    - src/api/**/*
+    - src/**/api/**/*
 area:frontend:
-  - app/**/*
+  - any:
+    - app/**/*
 area:infra:
-  - .github/**/*
-  - pyproject.toml
+  - any:
+    - .github/**/*
+    - pyproject.toml
 python:
-  - "**/*.py"
+  - any:
+    - "**/*.py"
 documentation:
-  - "**/*.md"
+  - any:
+    - "**/*.md"


### PR DESCRIPTION
The triage workflow uses `actions/labeler@v5` but the labeler config still uses v4 format (plain glob arrays). v5 expects config options with `any`/`all` keys.

Error on PR #46:
```
Error: found unexpected type for label area:api (should be array of config options)
```

This fix converts all label rules to v5 format, unblocking the labeler for all PRs.