### PR TITLE
Feat/task 7 api layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,10 @@ dependencies = [
 
 [project.optional-dependencies]
 api = [
-    "fastapi>=0.110.0",
-    "uvicorn[standard]>=0.29.0",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.34.0",
+    "python-multipart>=0.0.18",
+    "websockets>=14.0",
 ]
 
 [project.urls]

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """"Start the fu7ur3pr00f API server"""
 
-from fu7ur3pr00f.api.config import settings
 import uvicorn
+from fu7ur3pr00f.api.config import settings
 if __name__ == "__main__":
     uvicorn.run(
         "fu7ur3pr00f.api.app:app",

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-""""Start the fu7ur3pr00f API server"""
+"""Start the fu7ur3pr00f API server"""
 
 import uvicorn
+
 from fu7ur3pr00f.api.config import settings
+
 if __name__ == "__main__":
     uvicorn.run(
         "fu7ur3pr00f.api.app:app",

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """"Start the fu7ur3pr00f API server"""
 
-import uvicorn
 from fu7ur3pr00f.api.config import settings
+import uvicorn
 if __name__ == "__main__":
     uvicorn.run(
         "fu7ur3pr00f.api.app:app",

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -2,11 +2,11 @@
 """"Start the fu7ur3pr00f API server"""
 
 import uvicorn
-
+from fu7ur3pr00f.api.config import settings
 if __name__ == "__main__":
     uvicorn.run(
         "fu7ur3pr00f.api.app:app",
-        host="0.0.0.0",
-        port=8000,
+        host=settings.host,
+        port=settings.port,
         reload=True,
     )

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+""""Start the fu7ur3pr00f API server"""
+
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "fu7ur3pr00f.api.app:app",
+        host="0.0.0.0",
+        port=8000,
+        reload=True,
+    )


### PR DESCRIPTION
## Summary

Add a serve script for starting the FastAPI server and update API dependencies.

## Motivation

Task 7 requires a simple way to start the API server and support for the required API dependencies. The serve script uses the existing API configuration settings for host and port values.

## Changes

- Added `scripts/serve.py` to start the FastAPI server with Uvicorn.
- Updated FastAPI and Uvicorn dependency versions.
- Added `python-multipart` and `websockets` to the API dependency group.
- Configured the serve script to use `fu7ur3pr00f.api.config.settings` for host and port configuration.

## Testing

```bash
uv sync --extra api
python scripts/serve.py
curl http://localhost:8000/api/health
```

Response:

```json
{"status":"ok","version":"0.3.0"}
```

## Checklist

* [x] Changes are backwards compatible
* [ ] Tests pass locally (not run)
* [ ] Linting passes (`ruff check .`) (not run)
* [ ] Type checking passes (`pyright src/fu7ur3pr00f`) (not run)
* [ ] Documentation updated (not needed)

## Related Issues

Closes #15
