### PR TITLE
fix: resolve pyright errors in data attribute extraction

### DIFF
--- a/src/fu7ur3pr00f/gatherers/portfolio/js_extractor.py
+++ b/src/fu7ur3pr00f/gatherers/portfolio/js_extractor.py
@@ -162,9 +162,7 @@ class JSExtractor:
                 "email": item.get("email", ""),
             }
             if "sameAs" in item:
-                content.socials = [
-                    {"name": "Profile", "url": url} for url in item["sameAs"]
-                ]
+                content.socials = [{"name": "Profile", "url": url} for url in item["sameAs"]]
 
         # Extract CreativeWork or Project for projects
         elif item_type in ("CreativeWork", "Project", "SoftwareApplication"):
@@ -244,7 +242,7 @@ class JSExtractor:
         content = JSContent()
 
         # Extract project data from data attributes
-        for elem in soup.find_all(attrs={"data-project": True}):
+        for elem in soup.select("[data-project]"):
             try:
                 project_data = elem.get("data-project")
                 if project_data and isinstance(project_data, str):
@@ -255,7 +253,7 @@ class JSExtractor:
                 continue
 
         # Extract social links from data attributes
-        for elem in soup.find_all(attrs={"data-social": True}):
+        for elem in soup.select("[data-social]"):
             try:
                 social_data = elem.get("data-social")
                 if social_data and isinstance(social_data, str):
@@ -266,7 +264,7 @@ class JSExtractor:
                 continue
 
         # Extract bio from data attributes
-        for elem in soup.find_all(attrs={"data-bio": True}):
+        for elem in soup.select("[data-bio]"):
             try:
                 bio_data = elem.get("data-bio")
                 if bio_data and isinstance(bio_data, str):


### PR DESCRIPTION
## Summary
- Replace BeautifulSoup attrs=True searches with CSS attribute selectors
- Fixes pyright argument type errors in portfolio data-attribute extraction

## Test plan
- pyright src/fu7ur3pr00f
- pytest tests -q

Note: local pre-push format hook reports unrelated pre-existing formatting issues in 17 other files; this PR only formats the touched file.