### PR TITLE
ci: add stale issue management workflow (#40)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: "Stale issue handler"
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Every Monday at 6am
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has been inactive for 30 days. It will be closed in 7 days unless there is new activity."
+          close-issue-message: "This issue was closed due to inactivity. Feel free to reopen if it's still relevant."
+          days-before-stale: 30
+          days-before-close: 7
+          exempt-issue-labels: "epic,priority:critical,priority:high,help wanted"


### PR DESCRIPTION
## Description
Adds a GitHub Actions workflow (`stale.yml`) that runs weekly to automatically label inactive issues as stale and close them if no further activity occurs.

## Changes
- Created `.github/workflows/stale.yml` using `actions/stale@v9`.
- Configured 30 days inactivity before stale label and 7 days before close.
- Exempted `epic`, `priority:critical`, `priority:high`, and `help wanted` labels.

Closes #40