### PR TITLE
ci: configure dependabot for automated dependency updates (#38)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "area:infra"


### PR DESCRIPTION
## Description
Adds Dependabot configuration (`.github/dependabot.yml`) to automatically check and update Python (`pip`) dependencies on a weekly schedule.

## Changes
- Created `.github/dependabot.yml`.
- Configured weekly updates on Mondays.
- Set maximum open PRs limit to 10.
- Configured automatic labeling with `dependencies` and `area:infra`.

Closes #38